### PR TITLE
hotfix for embedded entity typing

### DIFF
--- a/multiplexer/multiplexer.go
+++ b/multiplexer/multiplexer.go
@@ -254,7 +254,7 @@ func (em *EMux) CreationMiddleware(entityID string) (func(next http.Handler) htt
 			}
 
 			muxCtx := muxContext.Create()
-			_ = muxCtx.Set(meta.EntityID, &preProcessedEntity)
+			_ = muxCtx.Set(meta.EntityID, preProcessedEntity.Interface())
 
 			reqWithCtx := muxCtx.EmbedCtx(r, context.Background())
 			next.ServeHTTP(w, reqWithCtx)

--- a/multiplexer/multiplexer_mw_test.go
+++ b/multiplexer/multiplexer_mw_test.go
@@ -87,13 +87,10 @@ func EntityMux_CreationMiddlewareRequestParseTestHelper(t *testing.T, rt *reqTes
 		if err != nil {
 			t.Fatal(err)
 		}
-		data, ok := muxCtx.Retrieve(rt.EntityID).(*reflect.Value)
-		if !ok {
-			t.Fatal("context retrieval fail", data)
-		}
+		data := muxCtx.Retrieve(rt.EntityID)
 
-		if !reflect.DeepEqual(data.Interface(), rt.ExpectedEntity) {
-			log.Print("got:      ", data.Elem().Interface())
+		if !reflect.DeepEqual(data, rt.ExpectedEntity) {
+			log.Print("got:      ", data)
 			log.Print("expected: ", rt.ExpectedEntity)
 			t.Fatal()
 		}


### PR DESCRIPTION
fixed reflected type embedding in request context
The embedded payload now can be retrieved and type-asserted against the Entity's type itself